### PR TITLE
adding 'BeginningOfDay" and "EndOfDay" overloads with TZ offset parameter

### DIFF
--- a/FluentDateTime/DateTime/DateTimeExtensions.cs
+++ b/FluentDateTime/DateTime/DateTimeExtensions.cs
@@ -12,19 +12,36 @@
 		/// <summary>
 		/// Returns the very end of the given day (the last millisecond of the last hour for the given <see cref="DateTime"/>).
 		/// </summary>
-		public static DateTime EndOfDay(this DateTime date)
-		{
+        public static DateTime EndOfDay(this DateTime date)
+        {
             return new DateTime(date.Year, date.Month, date.Day, 23, 59, 59, 999, date.Kind);
-		}
+        }
+
+        /// <summary>
+        /// Returns the timezone-adjusted very end of the given day (the last millisecond of the last hour for the given <see cref="DateTime"/>).
+        /// </summary>
+        public static DateTime EndOfDay(this DateTime date, int timeZoneOffset)
+        {
+            return new DateTime(date.Year, date.Month, date.Day, 23, 59, 59, 999, date.Kind)
+                .AddHours(timeZoneOffset);
+        }
 
 		/// <summary>
 		/// Returns the Start of the given day (the first millisecond of the given <see cref="DateTime"/>).
 		/// </summary>
-		public static DateTime BeginningOfDay(this DateTime date)
+        public static DateTime BeginningOfDay(this DateTime date)
 		{
             return new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, 0, date.Kind);
 		}
 
+        /// <summary>
+        /// Returns the timezone-adjusted Start of the given day (the first millisecond of the given <see cref="DateTime"/>).
+        /// </summary>
+        public static DateTime BeginningOfDay(this DateTime date, int timezoneOffset)
+        {
+            return new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, 0, date.Kind)
+                .AddHours(timezoneOffset);
+        }
 
 		/// <summary>
 		/// Returns the same date (same Day, Month, Hour, Minute, Second etc) in the next calendar year. 

--- a/FluentDateTimeTests/DateTimeTests.cs
+++ b/FluentDateTimeTests/DateTimeTests.cs
@@ -144,6 +144,35 @@ namespace FluentDateTimeTests
         }
 
         [Test]
+        public void TimeZoneTests()
+        {
+            /* story:
+             * 1. a web client submits a request to the server for "today",
+             * 2. a developer uses :BeginningOfDay and :EndOfDay to perform clamping server-side.
+             * 
+             * expected:
+             * 3. user expects a timezone-correct utc responses from the server, 
+             * 
+             * actual:
+             * 4. user receives a utc response that is too early (:BeginningOfDay), or
+             * 5. user receives a utc response that is too late (:EndOfDay)
+             */
+            for (int i = -11; i <= 12; i++)
+            {
+                var beginningOfDayUTC = new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                var actualDayStart = beginningOfDayUTC.BeginningOfDay(i);
+                var actualDayEnd = beginningOfDayUTC.EndOfDay(i);
+                var expectedDayStart = beginningOfDayUTC
+                    .AddHours(i);
+                var expectedDayEnd = beginningOfDayUTC
+                    .SetHour(23).SetMinute(59).SetSecond(59).SetMillisecond(999)
+                    .AddHours(i);
+                DateAssert.AreEqual(expectedDayStart, actualDayStart);
+                DateAssert.AreEqual(expectedDayEnd, actualDayEnd);
+            }
+        }
+
+        [Test]
         public void BasicTests()
         {
             var now = DateTime.Now;


### PR DESCRIPTION
adding 'BeginningOfDay" and "EndOfDay" overloads with a Time Zone offset for properly clamping to the start of day in any Time Zone (without incurring significant overhead)

unit test contains use case:

            /* story:
             * 1. a web client submits a request to the server for "today",
             * 2. a developer uses :BeginningOfDay and :EndOfDay to perform clamping server-side.
             * 
             * expected:
             * 3. user expects a timezone-correct utc responses from the server, 
             * 
             * actual:
             * 4. user receives a utc response that is too early (:BeginningOfDay), or
             * 5. user receives a utc response that is too late (:EndOfDay)
             */
