### PR TITLE
Add fluent date

### DIFF
--- a/src/FluentDateTime/FluentDate.cs
+++ b/src/FluentDateTime/FluentDate.cs
@@ -14,19 +14,19 @@ public class FluentDate
     /// <param name="day">
     /// The day (1 through the number of days in <paramref name="month" />).
     /// </param>
-    public FluentDate(int year, int month, int day) => DateTime = new(year, month, day, 0, 0, 0, DateTimeKind.Unspecified);
+    public FluentDate(int year, int month, int day) => Date = new(year, month, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 #if NET6_0_OR_GREATER
     /// <summary>
     /// Gets the current date.
     /// </summary>
-    public DateOnly Date => new(DateTime.Year, DateTime.Month, DateTime.Day);
+    public DateOnly DateOnly => new(Date.Year, Date.Month, Date.Day);
 #endif
 
     /// <summary>
     /// Gets midnight of the current date, with an unspecified time zone.
     /// </summary>
-    public DateTime DateTime { get; }
+    public DateTime Date { get; }
 
     /// <summary>
     /// Gets midnight of the current date in the Coordinated Universal Time (UTC) time zone.
@@ -99,7 +99,7 @@ public class FluentDate
     /// The milliseconds (0 through 999).
     /// </param>
     public DateTime At(DateTimeKind kind, int hour, int minute = 0, int second = 0, int millisecond = 0) =>
-        new(DateTime.Year, DateTime.Month, DateTime.Day, hour, minute, second, millisecond, kind);
+        new(Date.Year, Date.Month, Date.Day, hour, minute, second, millisecond, kind);
 
     /// <summary>
     /// Returns specified time at the current date and in a time zone expressed through <paramref name="offset" />.
@@ -120,12 +120,12 @@ public class FluentDate
     /// The milliseconds (0 through 999).
     /// </param>
     public DateTimeOffset At(TimeSpan offset, int hour, int minute = 0, int second = 0, int millisecond = 0) =>
-        new(DateTime.Year, DateTime.Month, DateTime.Day, hour, minute, second, millisecond, offset);
+        new(Date.Year, Date.Month, Date.Day, hour, minute, second, millisecond, offset);
 
 #if NET6_0_OR_GREATER
-    public static implicit operator DateOnly(FluentDate date) => date.Date;
+    public static implicit operator DateOnly(FluentDate date) => date.DateOnly;
 #endif
 
-    public static implicit operator DateTime(FluentDate date) => date.DateTime;
+    public static implicit operator DateTime(FluentDate date) => date.Date;
     public static implicit operator DateTimeOffset(FluentDate date) => (DateTime) date;
 }

--- a/src/FluentDateTime/FluentDate.cs
+++ b/src/FluentDateTime/FluentDate.cs
@@ -1,0 +1,131 @@
+namespace FluentDate;
+
+public class FluentDate
+{
+    /// <summary>
+    /// Initializes a new instance with the specified date.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="month">
+    /// The month (1 through 12).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through the number of days in <paramref name="month" />).
+    /// </param>
+    public FluentDate(int year, int month, int day) => DateTime = new(year, month, day, 0, 0, 0, DateTimeKind.Unspecified);
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Gets the current date.
+    /// </summary>
+    public DateOnly Date => new(DateTime.Year, DateTime.Month, DateTime.Day);
+#endif
+
+    /// <summary>
+    /// Gets midnight of the current date, with an unspecified time zone.
+    /// </summary>
+    public DateTime DateTime { get; }
+
+    /// <summary>
+    /// Gets midnight of the current date in the Coordinated Universal Time (UTC) time zone.
+    /// </summary>
+    public DateTime Utc => AtUtc(0);
+
+    /// <summary>
+    /// Gets midnight of the current date in the local time zone.
+    /// </summary>
+    public DateTime Local => AtLocal(0);
+
+    /// <summary>
+    /// Returns specified time at the current date.
+    /// </summary>
+    /// <param name="hour">
+    /// The hours (0 through 23).
+    /// </param>
+    /// <param name="minute">
+    /// The minutes (0 through 59).
+    /// </param>
+    /// <param name="second">
+    /// The seconds (0 through 59).
+    /// </param>
+    /// <param name="millisecond">
+    /// The milliseconds (0 through 999).
+    /// </param>
+    public DateTime At(int hour, int minute = 0, int second = 0, int millisecond = 0) =>
+        At(DateTimeKind.Unspecified, hour, minute, second, millisecond);
+
+    /// <summary>
+    /// Returns specified time at the current date.
+    /// </summary>
+    public DateTime AtUtc(int hour, int minute = 0, int second = 0, int millisecond = 0) =>
+        At(DateTimeKind.Utc, hour, minute, second, millisecond);
+
+    /// <summary>
+    /// Returns specified time at the current date.
+    /// </summary>
+    /// <param name="hour">
+    /// The hours (0 through 23).
+    /// </param>
+    /// <param name="minute">
+    /// The minutes (0 through 59).
+    /// </param>
+    /// <param name="second">
+    /// The seconds (0 through 59).
+    /// </param>
+    /// <param name="millisecond">
+    /// The milliseconds (0 through 999).
+    /// </param>
+    public DateTime AtLocal(int hour, int minute = 0, int second = 0, int millisecond = 0) =>
+        At(DateTimeKind.Local, hour, minute, second, millisecond);
+
+    /// <summary>
+    /// Returns specified time at the current date.
+    /// </summary>
+    /// <param name="kind">
+    /// One of the enumeration values that indicates whether <paramref name="hour" />, <paramref name="minute" />, <paramref name="second" />, and <paramref name="millisecond" /> specify a local time, Coordinated Universal Time (UTC), or neither.
+    /// </param>
+    /// <param name="hour">
+    /// The hours (0 through 23).
+    /// </param>
+    /// <param name="minute">
+    /// The minutes (0 through 59).
+    /// </param>
+    /// <param name="second">
+    /// The seconds (0 through 59).
+    /// </param>
+    /// <param name="millisecond">
+    /// The milliseconds (0 through 999).
+    /// </param>
+    public DateTime At(DateTimeKind kind, int hour, int minute = 0, int second = 0, int millisecond = 0) =>
+        new(DateTime.Year, DateTime.Month, DateTime.Day, hour, minute, second, millisecond, kind);
+
+    /// <summary>
+    /// Returns specified time at the current date.
+    /// </summary>
+    /// <param name="offset">
+    /// The time's offset from Coordinated Universal Time (UTC).
+    /// </param>
+    /// <param name="hour">
+    /// The hours (0 through 23).
+    /// </param>
+    /// <param name="minute">
+    /// The minutes (0 through 59).
+    /// </param>
+    /// <param name="second">
+    /// The seconds (0 through 59).
+    /// </param>
+    /// <param name="millisecond">
+    /// The milliseconds (0 through 999).
+    /// </param>
+    public DateTimeOffset At(TimeSpan offset, int hour, int minute = 0, int second = 0, int millisecond = 0) =>
+        new(DateTime.Year, DateTime.Month, DateTime.Day, hour, minute, second, millisecond, offset);
+
+#if NET6_0_OR_GREATER
+    public static implicit operator DateOnly(FluentDate date) => date.Date;
+#endif
+
+    public static implicit operator DateTime(FluentDate date) => date.DateTime;
+    public static implicit operator DateTimeOffset(FluentDate date) => (DateTime) date;
+}

--- a/src/FluentDateTime/FluentDate.cs
+++ b/src/FluentDateTime/FluentDate.cs
@@ -39,7 +39,7 @@ public class FluentDate
     public DateTime Local => AtLocal(0);
 
     /// <summary>
-    /// Returns specified time at the current date.
+    /// Returns specified time at the current date, with an unspecified time zone.
     /// </summary>
     /// <param name="hour">
     /// The hours (0 through 23).
@@ -57,13 +57,13 @@ public class FluentDate
         At(DateTimeKind.Unspecified, hour, minute, second, millisecond);
 
     /// <summary>
-    /// Returns specified time at the current date.
+    /// Returns specified time at the current date in the Coordinated Universal Time (UTC) time zone.
     /// </summary>
     public DateTime AtUtc(int hour, int minute = 0, int second = 0, int millisecond = 0) =>
         At(DateTimeKind.Utc, hour, minute, second, millisecond);
 
     /// <summary>
-    /// Returns specified time at the current date.
+    /// Returns specified time at the current date in the local time zone.
     /// </summary>
     /// <param name="hour">
     /// The hours (0 through 23).
@@ -102,7 +102,7 @@ public class FluentDate
         new(DateTime.Year, DateTime.Month, DateTime.Day, hour, minute, second, millisecond, kind);
 
     /// <summary>
-    /// Returns specified time at the current date.
+    /// Returns specified time at the current date and in a time zone expressed through <paramref name="offset" />.
     /// </summary>
     /// <param name="offset">
     /// The time's offset from Coordinated Universal Time (UTC).

--- a/src/FluentDateTime/IntExtensions.cs
+++ b/src/FluentDateTime/IntExtensions.cs
@@ -1,0 +1,257 @@
+namespace FluentDate;
+
+public static class IntExtensions
+{
+    /// <summary>
+    /// Returns the specified day in January of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate January(this int year, int day) => new(year, 1, day);
+
+    /// <summary>
+    /// Returns the specified day in January of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate Jan(this int year, int day) => year.January(day);
+
+    /// <summary>
+    /// Returns the specified day in February of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 28 in a common year, and 29 in leap years).
+    /// </param>
+    public static FluentDate February(this int year, int day) => new(year, 2, day);
+
+    /// <summary>
+    /// Returns the specified day in February of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 28 in a common year, and 29 in leap years).
+    /// </param>
+    public static FluentDate Feb(this int year, int day) => year.February(day);
+
+    /// <summary>
+    /// Returns the specified day in March of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate March(this int year, int day) => new(year, 3, day);
+
+    /// <summary>
+    /// Returns the specified day in March of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate Mar(this int year, int day) => year.March(day);
+
+    /// <summary>
+    /// Returns the specified day in April of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 30).
+    /// </param>
+    public static FluentDate April(this int year, int day) => new(year, 4, day);
+
+    /// <summary>
+    /// Returns the specified day in April of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 30).
+    /// </param>
+    public static FluentDate Apr(this int year, int day) => year.April(day);
+
+    /// <summary>
+    /// Returns the specified day in May of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate May(this int year, int day) => new(year, 5, day);
+
+    /// <summary>
+    /// Returns the specified day in June of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 30).
+    /// </param>
+    public static FluentDate June(this int year, int day) => new(year, 6, day);
+
+    /// <summary>
+    /// Returns the specified day in June of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 30).
+    /// </param>
+    public static FluentDate Jun(this int year, int day) => year.June(day);
+
+    /// <summary>
+    /// Returns the specified day in July of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate July(this int year, int day) => new(year, 7, day);
+
+    /// <summary>
+    /// Returns the specified day in July of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate Jul(this int year, int day) => year.July(day);
+
+    /// <summary>
+    /// Returns the specified day in August of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate August(this int year, int day) => new(year, 8, day);
+
+    /// <summary>
+    /// Returns the specified day in August of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate Aug(this int year, int day) => year.August(day);
+
+    /// <summary>
+    /// Returns the specified day in September of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 30).
+    /// </param>
+    public static FluentDate September(this int year, int day) => new(year, 9, day);
+
+    /// <summary>
+    /// Returns the specified day in September of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 30).
+    /// </param>
+    public static FluentDate Sep(this int year, int day) => year.September(day);
+
+    /// <summary>
+    /// Returns the specified day in October of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate October(this int year, int day) => new(year, 10, day);
+
+    /// <summary>
+    /// Returns the specified day in October of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate Oct(this int year, int day) => year.October(day);
+
+    /// <summary>
+    /// Returns the specified day in November of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 30).
+    /// </param>
+    public static FluentDate November(this int year, int day) => new(year, 11, day);
+
+    /// <summary>
+    /// Returns the specified day in November of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 30).
+    /// </param>
+    public static FluentDate Nov(this int year, int day) => year.November(day);
+
+    /// <summary>
+    /// Returns the specified day in December of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate December(this int year, int day) => new(year, 12, day);
+
+    /// <summary>
+    /// Returns the specified day in December of the specified year.
+    /// </summary>
+    /// <param name="year">
+    /// The year (1 through 9999).
+    /// </param>
+    /// <param name="day">
+    /// The day (1 through 31).
+    /// </param>
+    public static FluentDate Dec(this int year, int day) => year.December(day);
+}

--- a/src/FluentDateTime/IntExtensions.cs
+++ b/src/FluentDateTime/IntExtensions.cs
@@ -3,7 +3,7 @@ namespace FluentDate;
 public static class IntExtensions
 {
     /// <summary>
-    /// Returns the specified day in January of the year the method is called for.
+    /// Returns the specified day in January of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -14,7 +14,7 @@ public static class IntExtensions
     public static FluentDate January(this int year, int day) => new(year, 1, day);
 
     /// <summary>
-    /// Returns the specified day in January of the year the method is called for.
+    /// Returns the specified day in January of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -25,7 +25,7 @@ public static class IntExtensions
     public static FluentDate Jan(this int year, int day) => year.January(day);
 
     /// <summary>
-    /// Returns the specified day in February of the year the method is called for.
+    /// Returns the specified day in February of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -36,7 +36,7 @@ public static class IntExtensions
     public static FluentDate February(this int year, int day) => new(year, 2, day);
 
     /// <summary>
-    /// Returns the specified day in February of the year the method is called for.
+    /// Returns the specified day in February of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -47,7 +47,7 @@ public static class IntExtensions
     public static FluentDate Feb(this int year, int day) => year.February(day);
 
     /// <summary>
-    /// Returns the specified day in March of the year the method is called for.
+    /// Returns the specified day in March of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -58,7 +58,7 @@ public static class IntExtensions
     public static FluentDate March(this int year, int day) => new(year, 3, day);
 
     /// <summary>
-    /// Returns the specified day in March of the year the method is called for.
+    /// Returns the specified day in March of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -69,7 +69,7 @@ public static class IntExtensions
     public static FluentDate Mar(this int year, int day) => year.March(day);
 
     /// <summary>
-    /// Returns the specified day in April of the year the method is called for.
+    /// Returns the specified day in April of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -80,7 +80,7 @@ public static class IntExtensions
     public static FluentDate April(this int year, int day) => new(year, 4, day);
 
     /// <summary>
-    /// Returns the specified day in April of the year the method is called for.
+    /// Returns the specified day in April of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -91,7 +91,7 @@ public static class IntExtensions
     public static FluentDate Apr(this int year, int day) => year.April(day);
 
     /// <summary>
-    /// Returns the specified day in May of the year the method is called for.
+    /// Returns the specified day in May of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -102,7 +102,7 @@ public static class IntExtensions
     public static FluentDate May(this int year, int day) => new(year, 5, day);
 
     /// <summary>
-    /// Returns the specified day in June of the year the method is called for.
+    /// Returns the specified day in June of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -113,7 +113,7 @@ public static class IntExtensions
     public static FluentDate June(this int year, int day) => new(year, 6, day);
 
     /// <summary>
-    /// Returns the specified day in June of the year the method is called for.
+    /// Returns the specified day in June of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -124,7 +124,7 @@ public static class IntExtensions
     public static FluentDate Jun(this int year, int day) => year.June(day);
 
     /// <summary>
-    /// Returns the specified day in July of the year the method is called for.
+    /// Returns the specified day in July of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -135,7 +135,7 @@ public static class IntExtensions
     public static FluentDate July(this int year, int day) => new(year, 7, day);
 
     /// <summary>
-    /// Returns the specified day in July of the year the method is called for.
+    /// Returns the specified day in July of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -146,7 +146,7 @@ public static class IntExtensions
     public static FluentDate Jul(this int year, int day) => year.July(day);
 
     /// <summary>
-    /// Returns the specified day in August of the year the method is called for.
+    /// Returns the specified day in August of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -157,7 +157,7 @@ public static class IntExtensions
     public static FluentDate August(this int year, int day) => new(year, 8, day);
 
     /// <summary>
-    /// Returns the specified day in August of the year the method is called for.
+    /// Returns the specified day in August of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -168,7 +168,7 @@ public static class IntExtensions
     public static FluentDate Aug(this int year, int day) => year.August(day);
 
     /// <summary>
-    /// Returns the specified day in September of the year the method is called for.
+    /// Returns the specified day in September of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -179,7 +179,7 @@ public static class IntExtensions
     public static FluentDate September(this int year, int day) => new(year, 9, day);
 
     /// <summary>
-    /// Returns the specified day in September of the year the method is called for.
+    /// Returns the specified day in September of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -190,7 +190,7 @@ public static class IntExtensions
     public static FluentDate Sep(this int year, int day) => year.September(day);
 
     /// <summary>
-    /// Returns the specified day in October of the year the method is called for.
+    /// Returns the specified day in October of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -201,7 +201,7 @@ public static class IntExtensions
     public static FluentDate October(this int year, int day) => new(year, 10, day);
 
     /// <summary>
-    /// Returns the specified day in October of the year the method is called for.
+    /// Returns the specified day in October of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -212,7 +212,7 @@ public static class IntExtensions
     public static FluentDate Oct(this int year, int day) => year.October(day);
 
     /// <summary>
-    /// Returns the specified day in November of the year the method is called for.
+    /// Returns the specified day in November of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -223,7 +223,7 @@ public static class IntExtensions
     public static FluentDate November(this int year, int day) => new(year, 11, day);
 
     /// <summary>
-    /// Returns the specified day in November of the year the method is called for.
+    /// Returns the specified day in November of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -234,7 +234,7 @@ public static class IntExtensions
     public static FluentDate Nov(this int year, int day) => year.November(day);
 
     /// <summary>
-    /// Returns the specified day in December of the year the method is called for.
+    /// Returns the specified day in December of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -245,7 +245,7 @@ public static class IntExtensions
     public static FluentDate December(this int year, int day) => new(year, 12, day);
 
     /// <summary>
-    /// Returns the specified day in December of the year the method is called for.
+    /// Returns the specified day in December of the given year.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).

--- a/src/FluentDateTime/IntExtensions.cs
+++ b/src/FluentDateTime/IntExtensions.cs
@@ -3,7 +3,7 @@ namespace FluentDate;
 public static class IntExtensions
 {
     /// <summary>
-    /// Returns the specified day in January of the specified year.
+    /// Returns the specified day in January of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -14,7 +14,7 @@ public static class IntExtensions
     public static FluentDate January(this int year, int day) => new(year, 1, day);
 
     /// <summary>
-    /// Returns the specified day in January of the specified year.
+    /// Returns the specified day in January of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -25,7 +25,7 @@ public static class IntExtensions
     public static FluentDate Jan(this int year, int day) => year.January(day);
 
     /// <summary>
-    /// Returns the specified day in February of the specified year.
+    /// Returns the specified day in February of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -36,7 +36,7 @@ public static class IntExtensions
     public static FluentDate February(this int year, int day) => new(year, 2, day);
 
     /// <summary>
-    /// Returns the specified day in February of the specified year.
+    /// Returns the specified day in February of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -47,7 +47,7 @@ public static class IntExtensions
     public static FluentDate Feb(this int year, int day) => year.February(day);
 
     /// <summary>
-    /// Returns the specified day in March of the specified year.
+    /// Returns the specified day in March of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -58,7 +58,7 @@ public static class IntExtensions
     public static FluentDate March(this int year, int day) => new(year, 3, day);
 
     /// <summary>
-    /// Returns the specified day in March of the specified year.
+    /// Returns the specified day in March of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -69,7 +69,7 @@ public static class IntExtensions
     public static FluentDate Mar(this int year, int day) => year.March(day);
 
     /// <summary>
-    /// Returns the specified day in April of the specified year.
+    /// Returns the specified day in April of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -80,7 +80,7 @@ public static class IntExtensions
     public static FluentDate April(this int year, int day) => new(year, 4, day);
 
     /// <summary>
-    /// Returns the specified day in April of the specified year.
+    /// Returns the specified day in April of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -91,7 +91,7 @@ public static class IntExtensions
     public static FluentDate Apr(this int year, int day) => year.April(day);
 
     /// <summary>
-    /// Returns the specified day in May of the specified year.
+    /// Returns the specified day in May of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -102,7 +102,7 @@ public static class IntExtensions
     public static FluentDate May(this int year, int day) => new(year, 5, day);
 
     /// <summary>
-    /// Returns the specified day in June of the specified year.
+    /// Returns the specified day in June of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -113,7 +113,7 @@ public static class IntExtensions
     public static FluentDate June(this int year, int day) => new(year, 6, day);
 
     /// <summary>
-    /// Returns the specified day in June of the specified year.
+    /// Returns the specified day in June of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -124,7 +124,7 @@ public static class IntExtensions
     public static FluentDate Jun(this int year, int day) => year.June(day);
 
     /// <summary>
-    /// Returns the specified day in July of the specified year.
+    /// Returns the specified day in July of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -135,7 +135,7 @@ public static class IntExtensions
     public static FluentDate July(this int year, int day) => new(year, 7, day);
 
     /// <summary>
-    /// Returns the specified day in July of the specified year.
+    /// Returns the specified day in July of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -146,7 +146,7 @@ public static class IntExtensions
     public static FluentDate Jul(this int year, int day) => year.July(day);
 
     /// <summary>
-    /// Returns the specified day in August of the specified year.
+    /// Returns the specified day in August of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -157,7 +157,7 @@ public static class IntExtensions
     public static FluentDate August(this int year, int day) => new(year, 8, day);
 
     /// <summary>
-    /// Returns the specified day in August of the specified year.
+    /// Returns the specified day in August of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -168,7 +168,7 @@ public static class IntExtensions
     public static FluentDate Aug(this int year, int day) => year.August(day);
 
     /// <summary>
-    /// Returns the specified day in September of the specified year.
+    /// Returns the specified day in September of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -179,7 +179,7 @@ public static class IntExtensions
     public static FluentDate September(this int year, int day) => new(year, 9, day);
 
     /// <summary>
-    /// Returns the specified day in September of the specified year.
+    /// Returns the specified day in September of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -190,7 +190,7 @@ public static class IntExtensions
     public static FluentDate Sep(this int year, int day) => year.September(day);
 
     /// <summary>
-    /// Returns the specified day in October of the specified year.
+    /// Returns the specified day in October of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -201,7 +201,7 @@ public static class IntExtensions
     public static FluentDate October(this int year, int day) => new(year, 10, day);
 
     /// <summary>
-    /// Returns the specified day in October of the specified year.
+    /// Returns the specified day in October of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -212,7 +212,7 @@ public static class IntExtensions
     public static FluentDate Oct(this int year, int day) => year.October(day);
 
     /// <summary>
-    /// Returns the specified day in November of the specified year.
+    /// Returns the specified day in November of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -223,7 +223,7 @@ public static class IntExtensions
     public static FluentDate November(this int year, int day) => new(year, 11, day);
 
     /// <summary>
-    /// Returns the specified day in November of the specified year.
+    /// Returns the specified day in November of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -234,7 +234,7 @@ public static class IntExtensions
     public static FluentDate Nov(this int year, int day) => year.November(day);
 
     /// <summary>
-    /// Returns the specified day in December of the specified year.
+    /// Returns the specified day in December of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).
@@ -245,7 +245,7 @@ public static class IntExtensions
     public static FluentDate December(this int year, int day) => new(year, 12, day);
 
     /// <summary>
-    /// Returns the specified day in December of the specified year.
+    /// Returns the specified day in December of the year the method is called for.
     /// </summary>
     /// <param name="year">
     /// The year (1 through 9999).

--- a/src/Tests/FluentDateTests.cs
+++ b/src/Tests/FluentDateTests.cs
@@ -1,0 +1,134 @@
+﻿using FluentDate;
+using Xunit;
+
+public class FluentDateTests
+{
+    static Dictionary<int, Func<int, int, FluentDate.FluentDate>> fluentDatesFull = new()
+    {
+        [1] = (year, day) => year.January(day),
+        [2] = (year, day) => year.February(day),
+        [3] = (year, day) => year.March(day),
+        [4] = (year, day) => year.April(day),
+        [5] = (year, day) => year.May(day),
+        [6] = (year, day) => year.June(day),
+        [7] = (year, day) => year.July(day),
+        [8] = (year, day) => year.August(day),
+        [9] = (year, day) => year.September(day),
+        [10] = (year, day) => year.October(day),
+        [11] = (year, day) => year.November(day),
+        [12] = (year, day) => year.December(day)
+    };
+
+    static Dictionary<int, Func<int, int, FluentDate.FluentDate>> fluentDatesShort = new()
+    {
+        [1] = (year, day) => year.Jan(day),
+        [2] = (year, day) => year.Feb(day),
+        [3] = (year, day) => year.Mar(day),
+        [4] = (year, day) => year.Apr(day),
+        [5] = (year, day) => year.May(day),
+        [6] = (year, day) => year.Jun(day),
+        [7] = (year, day) => year.Jul(day),
+        [8] = (year, day) => year.Aug(day),
+        [9] = (year, day) => year.Sep(day),
+        [10] = (year, day) => year.Oct(day),
+        [11] = (year, day) => year.Nov(day),
+        [12] = (year, day) => year.Dec(day)
+    };
+
+    public static IEnumerable<object[]> FluentDates => fluentDatesFull.Concat(fluentDatesShort).Select(x => new object[]
+    {
+        x.Key,
+        x.Value
+    });
+
+    [Theory]
+    [MemberData(nameof(FluentDates))]
+    public void Dates(int month, Func<int, int, FluentDate.FluentDate> getFluentDate)
+    {
+        var date = GetRandomDateTimeOfMonth(month).DateTime;
+        var fluentDate = getFluentDate(date.Year, date.Day);
+
+        DateAssert.Equal(date.Date, fluentDate, "Implicit unequal");
+        DateAssert.Equal(date.Date, fluentDate.DateTime, "Explicit unequal");
+
+        DateAssert.Equal(DateTime.SpecifyKind(date.Date, DateTimeKind.Local), fluentDate.Local, "Local unequal");
+        DateAssert.Equal(DateTime.SpecifyKind(date.Date, DateTimeKind.Utc), fluentDate.Utc, "UTC unequal");
+
+#if NET6_0_OR_GREATER
+        Assert.Equal(DateOnly.FromDateTime(date), fluentDate.Date);
+#endif
+    }
+
+    [Theory]
+    [MemberData(nameof(FluentDates))]
+    public void DateAt(int month, Func<int, int, FluentDate.FluentDate> getFluentDate)
+    {
+        var date = GetRandomDateTimeOfMonth(month).DateTime;
+        var fluentDate = getFluentDate(date.Year, date.Day);
+
+        DateAssert.Equal(
+            date,
+            fluentDate.At(date.Hour, date.Minute, date.Second, date.Millisecond),
+            "Unspecified unequal");
+
+        DateAssert.Equal(
+            DateTime.SpecifyKind(date, DateTimeKind.Local),
+            fluentDate.AtLocal(date.Hour, date.Minute, date.Second, date.Millisecond),
+            "Local unequal");
+
+        DateAssert.Equal(
+            DateTime.SpecifyKind(date, DateTimeKind.Utc),
+            fluentDate.AtUtc(date.Hour, date.Minute, date.Second, date.Millisecond),
+            "UTC unequal");
+    }
+
+    [Theory]
+    [MemberData(nameof(FluentDates))]
+    public void DateAtWithKind(int month, Func<int, int, FluentDate.FluentDate> getFluentDate)
+    {
+        var date = GetRandomDateTimeOfMonth(month).DateTime;
+        var fluentDate = getFluentDate(date.Year, date.Day);
+
+        DateAssert.Equal(
+            date,
+            fluentDate.At(DateTimeKind.Unspecified, date.Hour, date.Minute, date.Second, date.Millisecond),
+            "Unspecified unequal");
+
+        DateAssert.Equal(
+            DateTime.SpecifyKind(date, DateTimeKind.Local),
+            fluentDate.At(DateTimeKind.Local, date.Hour, date.Minute, date.Second, date.Millisecond),
+            "Local unequal");
+
+        DateAssert.Equal(
+            DateTime.SpecifyKind(date, DateTimeKind.Utc),
+            fluentDate.At(DateTimeKind.Utc, date.Hour, date.Minute, date.Second, date.Millisecond),
+            "UTC unequal");
+    }
+
+    [Theory]
+    [MemberData(nameof(FluentDates))]
+    public void DateAtTimeZone(int month, Func<int, int, FluentDate.FluentDate> getFluentDate)
+    {
+        var date = GetRandomDateTimeOfMonth(month);
+        var fluentDate = getFluentDate(date.Year, date.Day);
+
+        Assert.Equal(date, fluentDate.At(date.Offset, date.Hour, date.Minute, date.Second, date.Millisecond));
+    }
+
+    DateTimeOffset GetRandomDateTimeOfMonth(int month)
+    {
+        Random random = new();
+
+        var year = random.Next(1, 10000);
+        return new(
+            year,
+            month,
+            random.Next(1, DateTime.DaysInMonth(year, month) + 1),
+            random.Next(0, 24),
+            random.Next(0, 60),
+            random.Next(0, 60),
+            random.Next(0, 1000),
+            TimeSpan.FromMinutes(random.Next((int) -12.Hours().TotalMinutes, (int) 14.Hours().TotalMinutes + 1))
+        );
+    }
+}

--- a/src/Tests/FluentDateTests.cs
+++ b/src/Tests/FluentDateTests.cs
@@ -49,13 +49,13 @@ public class FluentDateTests
         var fluentDate = getFluentDate(date.Year, date.Day);
 
         DateAssert.Equal(date.Date, fluentDate, "Implicit unequal");
-        DateAssert.Equal(date.Date, fluentDate.DateTime, "Explicit unequal");
+        DateAssert.Equal(date.Date, fluentDate.Date, "Explicit unequal");
 
         DateAssert.Equal(DateTime.SpecifyKind(date.Date, DateTimeKind.Local), fluentDate.Local, "Local unequal");
         DateAssert.Equal(DateTime.SpecifyKind(date.Date, DateTimeKind.Utc), fluentDate.Utc, "UTC unequal");
 
 #if NET6_0_OR_GREATER
-        Assert.Equal(DateOnly.FromDateTime(date), fluentDate.Date);
+        Assert.Equal(DateOnly.FromDateTime(date), fluentDate.DateOnly);
 #endif
     }
 


### PR DESCRIPTION
I was wondering if you would accept the following changes. My intention is to let specify dates by typing a month name next to an integer year like this: `2022.Apr(19)`, with a possibility to express time as well: `2022.Apr(19).At(22, 50)`. I thought I could propose these changes to you as they apparently seem to fit to your library, but I will understand if you don't agree ;). I just thought it would make no sense to create a separate NuGet package for this.

Thanks!