### PR TITLE
Remove the inner while loop for Add Business days extension

### DIFF
--- a/src/FluentDateTime/DateTime/DateTimeExtensions.cs
+++ b/src/FluentDateTime/DateTime/DateTimeExtensions.cs
@@ -452,10 +452,11 @@ public static class DateTimeExtensions
         var unsignedDays = Math.Abs(days);
         for (var i = 0; i < unsignedDays; i++)
         {
-            do
+            current = current.AddDays(sign);
+            if (current.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
             {
-                current = current.AddDays(sign);
-            } while (current.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday);
+                i--;
+            }
         }
         return current;
     }


### PR DESCRIPTION
Remove the while loop within the for loop. With this we 

- improve readability 
- reduce the cognitive load of having to think of two loops performing a task. 

